### PR TITLE
Bind Kestrel to Heroku's $PORT to fix H10 App crashed on container st…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN dotnet publish "./src/HBlog.Api/HBlog.Api.csproj" -c $BUILD_CONFIGURATION -o
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "HBlog.Api.dll"]
+CMD exec dotnet HBlog.Api.dll --urls "http://+:${PORT:-8080}"


### PR DESCRIPTION
…ack.

The container was listening on the .NET default 8080, but Heroku assigns a dynamic $PORT to each dyno. The container never bound to it, so Heroku SIGKILLed the process after the 60-second boot timeout and routed all requests to a 503/H10. Using shell-form CMD lets ${PORT} expand at container start; the :-8080 fallback preserves local `docker run` behavior. exec keeps SIGTERM reaching dotnet directly for clean dyno shutdowns.