### PR TITLE
Add user lookup by email and soft-delete endpoints

### DIFF
--- a/src/HBlog.Api/Controllers/UsersController.cs
+++ b/src/HBlog.Api/Controllers/UsersController.cs
@@ -35,7 +35,29 @@ namespace HBlog.Api.Controllers
 
             return Ok(user);
         }
-        
+
+        [HttpGet("users/by-email")]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult<UserDto>> GetUserByEmail([FromQuery] string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return BadRequest("email query parameter is required.");
+
+            var result = await _userService.GetMemberByEmailAsync(email);
+            if (result.Value is null)
+                return NotFound($"No user found for email: {email}");
+
+            return Ok(result.Value);
+        }
+
+        [HttpDelete("users/{id:guid}")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> DeleteUser(Guid id)
+        {
+            await _userService.DeleteMemberAsync(id);
+            return NoContent();
+        }
+
         [HttpPut("users")]
         public async Task<IActionResult> Update(UserUpdateDto userUpdateDto)
         {

--- a/src/HBlog.Application/Services/IUserService.cs
+++ b/src/HBlog.Application/Services/IUserService.cs
@@ -10,5 +10,7 @@ namespace HBlog.Application.Services
         Task<PageList<UserDto>> GetMembersAsync(UserParams userParams);
         Task<bool> UpdateMemberAsync(UserUpdateDto User);
         Task<ServiceResult<UserDto>> GetMembersByUsernameAsync(string username);
+        Task<ServiceResult<UserDto>> GetMemberByEmailAsync(string email);
+        Task<ServiceResult> DeleteMemberAsync(Guid id);
     }
 }

--- a/src/HBlog.Application/Services/UserService.cs
+++ b/src/HBlog.Application/Services/UserService.cs
@@ -49,6 +49,28 @@ namespace HBlog.Application.Services
             UserDto userDto = _mapper.Map<UserDto>(user);
             return ServiceResult.Success(userDto);
         }
+        public async Task<ServiceResult<UserDto>> GetMemberByEmailAsync(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                return ServiceResult.Fail<UserDto>(msg: "Email is required");
+
+            User user = await _userRepository.GetUserByEmailAsync(email);
+            if (user is null || user.IsDeleted)
+                return ServiceResult.Fail<UserDto>(msg: "User not found");
+
+            return ServiceResult.Success(_mapper.Map<UserDto>(user));
+        }
+
+        public async Task<ServiceResult> DeleteMemberAsync(Guid id)
+        {
+            User user = await _userRepository.GetUserByIdAsync(id);
+            if (user is null)
+                return ServiceResult.Success(msg: "User not found (already deleted)");
+
+            await _userRepository.SoftDeleteAsync(user);
+            return ServiceResult.Success(msg: "User deleted");
+        }
+
         public async Task<bool> UpdateMemberAsync(UserUpdateDto user)
         {
             UserUpdateDto userUpdateDto = new UserUpdateDto();

--- a/src/HBlog.Domain/Entities/User.cs
+++ b/src/HBlog.Domain/Entities/User.cs
@@ -16,6 +16,8 @@ namespace HBlog.Domain.Entities
         public string Email { get; set; }
         public string? RefreshToken { get; set; }
         public DateTime RefreshTokenExpiryTime { get; set; }
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedAtUtc { get; set; }
         public List<Photo> Photos { get; set; } = new();
         public ICollection<AppUserRole> UserRoles { get; set; }
     }

--- a/src/HBlog.Domain/Repositories/IUserRepository.cs
+++ b/src/HBlog.Domain/Repositories/IUserRepository.cs
@@ -8,5 +8,7 @@ namespace HBlog.Domain.Repositories
         Task<IEnumerable<User>> GetUsersAsync();
         Task<User> GetUserByIdAsync(Guid id);
         Task<User> GetUserByUsernameAsync(string username);
+        Task<User> GetUserByEmailAsync(string email);
+        Task<bool> SoftDeleteAsync(User user);
     }
 }

--- a/src/HBlog.Infrastructure/Migrations/Identity/20260707031438_AddUserSoftDelete.Designer.cs
+++ b/src/HBlog.Infrastructure/Migrations/Identity/20260707031438_AddUserSoftDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HBlog.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HBlog.Infrastructure.Migrations.Identity
 {
     [DbContext(typeof(IdentityContext))]
-    partial class IdentityContextModelSnapshot : ModelSnapshot
+    [Migration("20260707031438_AddUserSoftDelete")]
+    partial class AddUserSoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/HBlog.Infrastructure/Migrations/Identity/20260707031438_AddUserSoftDelete.cs
+++ b/src/HBlog.Infrastructure/Migrations/Identity/20260707031438_AddUserSoftDelete.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HBlog.Infrastructure.Migrations.Identity
+{
+    /// <inheritdoc />
+    public partial class AddUserSoftDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAtUtc",
+                table: "User",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "User",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAtUtc",
+                table: "User");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "User");
+        }
+    }
+}

--- a/src/HBlog.Infrastructure/Repositories/UserRepository.cs
+++ b/src/HBlog.Infrastructure/Repositories/UserRepository.cs
@@ -21,6 +21,14 @@ namespace HBlog.Infrastructure.Repositories
             return await _dbContext.Users.Include(p => p.Photos).SingleOrDefaultAsync(x => x.UserName == username);
         }
 
+        public async Task<User> GetUserByEmailAsync(string email)
+        {
+            var normalized = email?.ToUpperInvariant();
+            return await _dbContext.Users
+                .Include(p => p.Photos)
+                .SingleOrDefaultAsync(x => x.NormalizedEmail == normalized);
+        }
+
         public async Task<IEnumerable<User>> GetUsersAsync()
         {
             return await _dbContext.Users.Include(p=> p.Photos).AsNoTracking().ToListAsync();
@@ -32,6 +40,31 @@ namespace HBlog.Infrastructure.Repositories
         public void Update(User user)
         {
             _dbContext.Entry(user).State = EntityState.Modified;
+        }
+
+        public async Task<bool> SoftDeleteAsync(User user)
+        {
+            if (user is null) return false;
+            if (user.IsDeleted) return true;
+
+            var sentinel = $"deleted_{user.Id:N}";
+            user.IsDeleted = true;
+            user.DeletedAtUtc = DateTime.UtcNow;
+            user.UserName = sentinel;
+            user.NormalizedUserName = sentinel.ToUpperInvariant();
+            user.Email = $"{sentinel}@invalid.local";
+            user.NormalizedEmail = user.Email.ToUpperInvariant();
+            user.FirstName = null;
+            user.LastName = null;
+            user.KnownAs = null;
+            user.DateOfBirth = default;
+            user.Gender = null;
+            user.RefreshToken = null;
+            user.PhoneNumber = null;
+            user.PhoneNumberConfirmed = false;
+
+            _dbContext.Entry(user).State = EntityState.Modified;
+            return await _dbContext.SaveChangesAsync() > 0;
         }
     }
 }


### PR DESCRIPTION
- GET /api/users/by-email?email={email} resolves email to user (Admin only)
- DELETE /api/users/{id} soft-deletes with PII scrub (Admin only, idempotent)
- User gains IsDeleted / DeletedAtUtc columns via AddUserSoftDelete migration
- Soft delete renames UserName/Email to a `deleted_{id}` sentinel so Identity unique indexes stay valid and the address can be reclaimed on re-registration

External IdP (Google/Apple) revocation is intentionally out of scope for this pass; soft-deleted rows are hidden from lookups so local login is already blocked.