### PR TITLE
Auto-link OAuth sign-in to existing account by verified email

### DIFF
--- a/src/HBlog.Api/Controllers/AccountController.cs
+++ b/src/HBlog.Api/Controllers/AccountController.cs
@@ -129,13 +129,35 @@ namespace HBlog.Api.Controllers
             var existingLink = await _userManager.FindByLoginAsync(identity.Provider, identity.Subject);
             if (existingLink is not null) return await IssueTokensAsync(existingLink);
 
-            if (await UserExists(dto.UserName)) return BadRequest("Username is taken");
-            if (await EmailExists(dto.Email)) return BadRequest("Email is taken");
+            if (!string.IsNullOrEmpty(identity.Email))
+            {
+                var existingByEmail = await _userManager.FindByEmailAsync(identity.Email);
+                if (existingByEmail is not null)
+                {
+                    if (!identity.EmailVerified)
+                        return StatusCode((int)HttpStatusCode.Forbidden, new Microsoft.AspNetCore.Mvc.ProblemDetails
+                        {
+                            Status = (int)HttpStatusCode.Forbidden,
+                            Title = "Forbidden",
+                            Detail = "Email not verified by provider. Sign in with password instead.",
+                        });
+
+                    var linkResult = await _userManager.AddLoginAsync(existingByEmail,
+                        new UserLoginInfo(identity.Provider, identity.Subject, identity.Provider));
+                    if (!linkResult.Succeeded) return BadRequest(linkResult.Errors);
+                    return await IssueTokensAsync(existingByEmail);
+                }
+            }
+
+            var email = !string.IsNullOrEmpty(identity.Email) ? identity.Email : dto.Email;
+
+            if (await UserExists(dto.UserName)) return Conflict("Username is taken");
+            if (await EmailExists(email)) return Conflict("Email is taken");
 
             var user = new User
             {
                 UserName = dto.UserName,
-                Email = dto.Email,
+                Email = email,
                 FirstName = string.IsNullOrWhiteSpace(dto.FirstName) ? (identity.GivenName ?? string.Empty) : dto.FirstName,
                 LastName = string.IsNullOrWhiteSpace(dto.LastName) ? (identity.FamilyName ?? string.Empty) : dto.LastName,
                 KnownAs = dto.UserName,


### PR DESCRIPTION
Close the account-takeover gap where an OAuth sign-in whose email matches an existing password account either failed hard ("Email is taken") or, if the provider hadn't verified the email, could have been used to hijack the local account. /account/oauth/complete now:

- Auto-links the external login onto the existing user when the ticket's emailVerified claim is true (client-supplied profile fields ignored).
- Returns 403 when the email matches but the provider did not verify it, so the client can prompt "Sign in with password instead."
- Uses the ticket's verified email on new-user registration, falling back to the client-supplied email only when the provider did not supply one.
- Returns 409 (was 400) on username/email collisions, matching the Flutter client's retry UX.